### PR TITLE
Fix parsing

### DIFF
--- a/fandom/FandomPage.py
+++ b/fandom/FandomPage.py
@@ -234,7 +234,7 @@ class FandomPage(object):
             section_text = ""
             current_level = header_level
           #elif next_node.name == 'div':
-          elif (not next_node.has_attr('class')) or (next_node['class'][0] != "printfooter"):
+          elif (not next_node.has_attr('class')) or (next_node['class'] and next_node['class'][0] != "printfooter"):
             section_text += "\n"+next_node.get_text()
         next_node = next_node.nextSibling
 


### PR DESCRIPTION
I was getting the following:
```
Traceback (most recent call last):
  File "wiki_connection.py", line 5, in <module>
    print(page.plain_text)
  File "/usr/local/lib/python3.8/dist-packages/fandom/FandomPage.py", line 401, in plain_text
    self._plain_text = self.section(self.title)
  File "/usr/local/lib/python3.8/dist-packages/fandom/FandomPage.py", line 384, in section
    return get_section_recursive([self.content], self.content['title'].lower())
  File "/usr/local/lib/python3.8/dist-packages/fandom/FandomPage.py", line 237, in content
    elif (not next_node.has_attr('class')) or (next_node['class'][0] != "printfooter"):
IndexError: list index out of range
```